### PR TITLE
Add file lock for cache_path

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/lib/money_oxr/rates_store.rb
+++ b/lib/money_oxr/rates_store.rb
@@ -40,11 +40,11 @@ module MoneyOXR
 
     def load
       # Loads data and ensures it is not stale.
-      if !loaded? && cache_path && File.exist?(cache_path)
-        load_from_cache_path
-      end
-      if app_id && (!loaded? || stale?)
-        load_from_api
+      return if loaded? && !stale?
+
+      with_cache_file_lock do
+        load_from_cache_path if cache_path && File.exists?(cache_path)
+        load_from_api if app_id && stale?
       end
     end
 
@@ -58,6 +58,7 @@ module MoneyOXR
       json = get_json_from_api
       # Protect against saving or loading nil/bad data from API.
       return unless json && json =~ /rates/
+
       if cache_path
         write_cache_file(json)
         load_from_cache_path
@@ -79,7 +80,8 @@ module MoneyOXR
     end
 
     def load_from_cache_path
-      load_json(File.read(cache_path))
+      json = File.read(cache_path)
+      load_json(json) unless json.empty?
     end
 
     def write_cache_file(text)
@@ -107,5 +109,18 @@ module MoneyOXR
       data
     end
 
+    private
+
+    def with_cache_file_lock
+      return yield unless cache_path
+      File.open(cache_path, 'a') do |cache_io|
+        cache_io.flock(File::LOCK_EX)
+        begin
+          yield
+        ensure
+          cache_io.flock(File::LOCK_UN)
+        end
+      end
+    end
   end
 end

--- a/money-oxr.gemspec
+++ b/money-oxr.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.3"
+  spec.add_development_dependency "pry-byebug"
 end

--- a/spec/money_oxr/rates_store_spec.rb
+++ b/spec/money_oxr/rates_store_spec.rb
@@ -93,6 +93,19 @@ RSpec.describe MoneyOXR::RatesStore do
       json = File.read(tmp_cache_path)
       expect(json).to eq json_string
     end
+
+    it 'loads json data only once if cache_path provided' do
+      api_request = stub_api(app_id: 'abc1234', source: 'USD', delay_response: 0.1)
+
+      Array.new(2) do
+        Thread.new do
+          described_class.new(app_id: 'abc1234', cache_path: tmp_cache_path, max_age: 600).load
+        end
+      end.each(&:join)
+
+      expect(api_request).to have_been_made.once
+    end
+
     it 'raises error on API failure if on_api_failure is not :warn' do
       subject = described_class.new app_id: 'abc1234', cache_path: tmp_cache_path, on_api_failure: :error
       stub_api(app_id: 'abc1234', source: 'USD', status: 401, body: nil)
@@ -163,13 +176,18 @@ RSpec.describe MoneyOXR::RatesStore do
 
   private
 
-  def stub_api(app_id:, source: 'USD', body: json_string.gsub('1521291605', Time.now.to_i.to_s), status: 200)
+  def stub_api(app_id:, source: 'USD', body: json_string.gsub('1521291605', Time.now.to_i.to_s), status: 200, delay_response: 0)
     stub_request(
       :get,
       "https://openexchangerates.org/api/latest.json?app_id=#{app_id}&base=#{source}"
     ).to_return(
       status: status,
-      body: body
+      body: (
+        proc do
+          sleep delay_response unless delay_response.zero?
+          body
+        end
+      )
     )
   end
 


### PR DESCRIPTION
Old behavior: when money rates become stale, all workers request api

New behavior: when money rates become stale, first worker takes an
excludsive lock and other workers are waiting until it will
download and store new rates in cache_path. Then they will reload cache
and find it's data not stale

Also added .editorconfig and 'pry' dependency